### PR TITLE
Add SetNX command

### DIFF
--- a/examples/strs/main.go
+++ b/examples/strs/main.go
@@ -40,4 +40,17 @@ func main() {
 		fmt.Printf("delete data err: %v", err)
 		return
 	}
+
+	err = db.SetNX([]byte("cmd"), []byte("SetNX"))
+	if err != nil {
+		fmt.Printf("write data err: %v", err)
+		return
+	}
+
+	v, err = db.Get([]byte("cmd"))
+	if err != nil {
+		fmt.Printf("read data err: %v", err)
+		return
+	}
+	fmt.Printf("cmd-type = %s", string(v))
 }

--- a/strs.go
+++ b/strs.go
@@ -1,6 +1,7 @@
 package rosedb
 
 import (
+	"errors"
 	"github.com/flower-corp/rosedb/logfile"
 	"github.com/flower-corp/rosedb/logger"
 	"time"
@@ -77,6 +78,9 @@ func (db *RoseDB) SetNX(key, value []byte) error {
 
 	val, err := db.getVal(key)
 
+	if err != nil && !errors.Is(err, ErrKeyNotFound) {
+		return err
+	}
 	// Key exists in db.
 	if val != nil {
 		return nil


### PR DESCRIPTION
Related to https://github.com/flower-corp/rosedb/issues/100

* `SetNX()` command added.
* Tests added for `SetNX`.
* Example code added for `SetNX`.

Signed-off-by: Gökhan Özeloğlu <gozeloglu@gmail.com>