### PR TITLE
Add key length comparison for MGet

### DIFF
--- a/strs.go
+++ b/strs.go
@@ -36,6 +36,11 @@ func (db *RoseDB) Get(key []byte) ([]byte, error) {
 func (db *RoseDB) MGet(keys [][]byte) ([][]byte, error) {
 	db.strIndex.mu.Lock()
 	defer db.strIndex.mu.Unlock()
+
+	if len(keys) == 0 {
+		return nil, ErrWrongNumberOfArgs
+	}
+
 	values := make([][]byte, len(keys))
 	for i, key := range keys {
 		if val, err := db.getVal(key); err != nil && !errors.Is(ErrKeyNotFound, err) {

--- a/strs_test.go
+++ b/strs_test.go
@@ -281,6 +281,12 @@ func testRoseDBMGet(t *testing.T, ioType IOType, mode DataIndexMode) {
 			want:    [][]byte{nil, []byte("v-1")},
 			wantErr: false,
 		},
+		{
+			name:    "empty key",
+			db:      db,
+			args:    args{keys: [][]byte{}},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
* Bug fixed.
* ErrWrongNumberOfArgs is returned.
* Test case added.

`MGet` method returns an error if any key does not pass.

Signed-off-by: Gökhan Özeloğlu <gozeloglu@gmail.com>