### PR TITLE
fix: out of index should return ErrWrongIndex

### DIFF
--- a/benchmark/db_bench_test.go
+++ b/benchmark/db_bench_test.go
@@ -2,17 +2,18 @@ package benchmark
 
 import (
 	"fmt"
-	"github.com/flower-corp/rosedb"
-	"github.com/stretchr/testify/assert"
 	"math/rand"
 	"path/filepath"
 	"testing"
+
+	"github.com/flower-corp/rosedb"
+	"github.com/stretchr/testify/assert"
 )
 
 var roseDB *rosedb.RoseDB
 
 func init() {
-	path := filepath.Join("/tmp", "rosedb")
+	path := filepath.Join("/tmp", "rosedb_Bench")
 	opts := rosedb.DefaultOptions(path)
 	var err error
 	roseDB, err = rosedb.Open(opts)

--- a/benchmark/db_bench_test.go
+++ b/benchmark/db_bench_test.go
@@ -13,7 +13,7 @@ import (
 var roseDB *rosedb.RoseDB
 
 func init() {
-	path := filepath.Join("/tmp", "rosedb_Bench")
+	path := filepath.Join("/tmp", "rosedb_bench")
 	opts := rosedb.DefaultOptions(path)
 	var err error
 	roseDB, err = rosedb.Open(opts)

--- a/list.go
+++ b/list.go
@@ -2,6 +2,7 @@ package rosedb
 
 import (
 	"encoding/binary"
+
 	"github.com/flower-corp/rosedb/ds/art"
 	"github.com/flower-corp/rosedb/logfile"
 	"github.com/flower-corp/rosedb/logger"
@@ -153,6 +154,10 @@ func (db *RoseDB) LIndex(key []byte, index int) ([]byte, error) {
 		return nil, err
 	}
 
+	if seq >= tailSeq || seq <= headSeq {
+		return nil, ErrWrongIndex
+	}
+
 	encKey := db.encodeListKey(key, seq)
 	val, err := db.getVal(idxTree, encKey, List)
 	if err != nil {
@@ -183,7 +188,7 @@ func (db *RoseDB) LSet(key []byte, index int, value []byte) error {
 	if seq >= tailSeq || seq <= headSeq {
 		return ErrWrongIndex
 	}
-	
+
 	encKey := db.encodeListKey(key, seq)
 	ent := &logfile.LogEntry{Key: encKey, Value: value}
 	valuePos, err := db.writeLogEntry(ent, List)
@@ -239,7 +244,7 @@ func (db *RoseDB) LRange(key []byte, start, end int) (values [][]byte, err error
 		endSeq = tailSeq - 1
 	}
 
-	if startSeq >= tailSeq || endSeq <= headSeq || startSeq > endSeq{
+	if startSeq >= tailSeq || endSeq <= headSeq || startSeq > endSeq {
 		return nil, ErrWrongIndex
 	}
 

--- a/list_test.go
+++ b/list_test.go
@@ -1,9 +1,10 @@
 package rosedb
 
 import (
-	"github.com/stretchr/testify/assert"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRoseDB_LPush(t *testing.T) {
@@ -565,7 +566,6 @@ func testRoseDBLSet(t *testing.T, ioType IOType, mode DataIndexMode) {
 	assert.Equal(t, err, ErrWrongIndex)
 }
 
-
 func TestRoseDB_listSequence(t *testing.T) {
 
 	t.Run("fileio", func(t *testing.T) {
@@ -641,7 +641,6 @@ func testListSequence(t *testing.T, ioType IOType, mode DataIndexMode) {
 		})
 	}
 }
-
 
 func TestRoseDB_LRange(t *testing.T) {
 	t.Run("fileio", func(t *testing.T) {


### PR DESCRIPTION
We should return an exact err value.

![image](https://user-images.githubusercontent.com/38528079/172540311-fd636df7-6227-41f3-a514-f319eeb75a9c.png)
