### PR TITLE
refactor HSet to HMSet function

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -26,9 +26,9 @@ func (db *RoseDB) HSet(key []byte, args ...[]byte) error {
 
 	// add multiple field value pairs
 	for i := 0; i < len(args); i += 2 {
-		f, v := args[i], args[i+1]
-		hashKey := db.encodeKey(key, f)
-		entry := &logfile.LogEntry{Key: hashKey, Value: v}
+		field, value := args[i], args[i+1]
+		hashKey := db.encodeKey(key, field)
+		entry := &logfile.LogEntry{Key: hashKey, Value: value}
 		valuePos, err := db.writeLogEntry(entry, Hash)
 		if err != nil {
 			return err
@@ -39,7 +39,7 @@ func (db *RoseDB) HSet(key []byte, args ...[]byte) error {
 		}
 		idxTree := db.hashIndex.trees[string(key)]
 
-		ent := &logfile.LogEntry{Key: f, Value: v}
+		ent := &logfile.LogEntry{Key: field, Value: value}
 		_, size := logfile.EncodeEntry(entry)
 		valuePos.entrySize = size
 		err = db.updateIndexTree(idxTree, ent, valuePos, true, Hash)

--- a/hash.go
+++ b/hash.go
@@ -15,25 +15,39 @@ import (
 // HSet sets field in the hash stored at key to value. If key does not exist, a new key holding a hash is created.
 // If field already exists in the hash, it is overwritten.
 // Return num of elements in hash of the specified key.
-func (db *RoseDB) HSet(key, field, value []byte) error {
+// Multiple field-value pair is accepted. Parameter order should be like "key", "field", "value", "field", "value"...
+func (db *RoseDB) HSet(key []byte, args ...[]byte) error {
 	db.hashIndex.mu.Lock()
 	defer db.hashIndex.mu.Unlock()
 
-	hashKey := db.encodeKey(key, field)
-	ent := &logfile.LogEntry{Key: hashKey, Value: value}
-	valuePos, err := db.writeLogEntry(ent, Hash)
-	if err != nil {
-		return err
+	if len(args) == 0 || len(args)&1 == 1 {
+		return ErrWrongNumberOfArgs
 	}
 
-	if db.hashIndex.trees[string(key)] == nil {
-		db.hashIndex.trees[string(key)] = art.NewART()
+	// add multiple field value pairs
+	for i := 0; i < len(args); i += 2 {
+		f, v := args[i], args[i+1]
+		hashKey := db.encodeKey(key, f)
+		entry := &logfile.LogEntry{Key: hashKey, Value: v}
+		valuePos, err := db.writeLogEntry(entry, Hash)
+		if err != nil {
+			return err
+		}
+
+		if db.hashIndex.trees[string(key)] == nil {
+			db.hashIndex.trees[string(key)] = art.NewART()
+		}
+		idxTree := db.hashIndex.trees[string(key)]
+
+		ent := &logfile.LogEntry{Key: f, Value: v}
+		_, size := logfile.EncodeEntry(entry)
+		valuePos.entrySize = size
+		err = db.updateIndexTree(idxTree, ent, valuePos, true, Hash)
+		if err != nil {
+			return err
+		}
 	}
-	idxTree := db.hashIndex.trees[string(key)]
-	entry := &logfile.LogEntry{Key: field, Value: value}
-	_, size := logfile.EncodeEntry(ent)
-	valuePos.entrySize = size
-	return db.updateIndexTree(idxTree, entry, valuePos, true, Hash)
+	return nil
 }
 
 // HSetNX sets the given value only if the field doesn't exist.

--- a/hash_test.go
+++ b/hash_test.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"path/filepath"
 	"testing"
-
+	"errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,7 +12,7 @@ func TestRoseDB_HSet(t *testing.T) {
 	t.Run("fileio", func(t *testing.T) {
 		testRoseDBHSet(t, FileIO, KeyOnlyMemMode)
 	})
-	t.Run("fileio", func(t *testing.T) {
+	t.Run("mmap", func(t *testing.T) {
 		testRoseDBHSet(t, MMap, KeyValueMemMode)
 	})
 }
@@ -27,9 +27,8 @@ func testRoseDBHSet(t *testing.T, ioType IOType, mode DataIndexMode) {
 	defer destroyDB(db)
 
 	type args struct {
-		key   []byte
-		field []byte
-		value []byte
+		key []byte
+		arg [][]byte
 	}
 	tests := []struct {
 		name    string
@@ -38,22 +37,49 @@ func testRoseDBHSet(t *testing.T, ioType IOType, mode DataIndexMode) {
 		wantErr bool
 	}{
 		{
-			"nil", db, args{key: nil, field: nil, value: GetKey(123)}, false,
+			"nil-key-and-field", db, args{key: nil, arg: [][]byte{nil, []byte("val-0")}}, false,
 		},
 		{
-			"nil-value", db, args{key: GetKey(1), field: GetKey(11), value: nil}, false,
+			"wrong-num-of-args", db, args{key: GetKey(2), arg: [][]byte{[]byte("field-0")}}, true,
 		},
 		{
-			"normal", db, args{key: GetKey(1), field: GetKey(11), value: GetValue16B()}, false,
+			"normal-single-pair", db, args{key: GetKey(3), arg: [][]byte{[]byte("field-0"), []byte("val-0")}}, false,
+		},
+		{
+			"normal-mulit-pair", db, args{key: GetKey(4), arg: [][]byte{[]byte("field-0"), []byte("val-0"),
+				[]byte("field-1"), []byte("val-1")}}, false,
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.db.HSet(tt.args.key, tt.args.field, tt.args.value); (err != nil) != tt.wantErr {
+			err := tt.db.HSet(tt.args.key, tt.args.arg...)
+			if (err != nil) != tt.wantErr {
 				t.Errorf("HSet() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && !errors.Is(err, ErrWrongNumberOfArgs) {
+				t.Errorf("HSet() error = %v, expected error = %v", err, ErrWrongNumberOfArgs)
 			}
 		})
 	}
+
+	t.Run("check-nil-key-and-field", func(t *testing.T) {
+		val, err := db.HGet(nil, nil)
+		assert.Nil(t, err)
+		assert.Equal(t, []byte(nil), val)
+	})
+
+	t.Run("check-single-field", func(t *testing.T) {
+		val, err := db.HGet(GetKey(3), []byte("field-0"))
+		assert.Nil(t, err)
+		assert.Equal(t, []byte("val-0"), val, "single field not same")
+	})
+
+	t.Run("check-mulit-field", func(t *testing.T) {
+		value, err := db.HMGet(GetKey(4), []byte("field-0"), []byte("field-1"))
+		assert.Nil(t, err)
+		assert.Equal(t, [][]byte{[]byte("val-0"), []byte("val-1")}, value, "multi field not same")
+	})
 }
 
 func TestRoseDB_HSetNX(t *testing.T) {


### PR DESCRIPTION
- refactor HSet with HMSet function to accept multi field-value pairs 
- why I didn't just add HMSet func?
    - since Redis do the same thing after 4.0.0, HMSet is deprecated.