### PR TITLE
remove SIGKILL signal in signal handler

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -74,8 +74,7 @@ func main() {
 	logger.Infof("open db from [%s] successfully, time cost: %v", serverOpts.dbPath, time.Since(now))
 
 	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGKILL, syscall.SIGHUP,
-		syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	signal.Notify(sig, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 
 	dbs := make(map[int]*rosedb.RoseDB)
 	dbs[0] = db

--- a/db.go
+++ b/db.go
@@ -487,7 +487,7 @@ func (db *RoseDB) handleLogFileGC() {
 	}
 
 	quitSig := make(chan os.Signal, 1)
-	signal.Notify(quitSig, syscall.SIGKILL, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	signal.Notify(quitSig, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 	ticker := time.NewTicker(db.opts.LogFileGCInterval)
 	defer ticker.Stop()
 	for {


### PR DESCRIPTION
In linux system, SIGKILL signal cannot be caught and handled by user, (also the SIGSTOP signal), actually, I think we can only care about SIGINT and SINTERM, which is the common practice，I maybe check them in future and  create another PR