### PR TITLE
fix the rare case of infinite loop

### DIFF
--- a/ds/zset/zset.go
+++ b/ds/zset/zset.go
@@ -450,7 +450,7 @@ func newSkipList() *skipList {
 func randomLevel() int16 {
 	var level int16 = 1
 	for level < maxLevel {
-		if rand.Float64() >= probability {
+		if rand.Float64() < probability {
 			break
 		}
 		level++

--- a/ds/zset/zset.go
+++ b/ds/zset/zset.go
@@ -1,10 +1,11 @@
 package zset
 
 import (
-	"github.com/flower-corp/rosedb/logfile"
-	"github.com/flower-corp/rosedb/util"
 	"math"
 	"math/rand"
+
+	"github.com/flower-corp/rosedb/logfile"
+	"github.com/flower-corp/rosedb/util"
 )
 
 // zset is the implementation of sorted set
@@ -448,15 +449,13 @@ func newSkipList() *skipList {
 
 func randomLevel() int16 {
 	var level int16 = 1
-	for float32(rand.Int31()&0xFFFF) < (probability * 0xFFFF) {
+	for level < maxLevel {
+		if rand.Float64() >= probability {
+			break
+		}
 		level++
 	}
-
-	if level < maxLevel {
-		return level
-	}
-
-	return maxLevel
+	return level
 }
 
 func (skl *skipList) sklInsert(score float64, member string) *sklNode {


### PR DESCRIPTION
[The function `randomLevel`](https://github.com/flower-corp/rosedb/blob/main/ds/zset/zset.go#L449) has a very low probability to fall into an infinite loop. Besides, we can use `rand.Float64()` to generate a pseudo-random number between 0.0 and 1.0, instead of using rand.Int31() and the mask operation.