### PR TITLE
feat: add atomic cas for string

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -64,7 +64,7 @@ func (db *RoseDB) HSetNX(key, field, value []byte) (bool, error) {
 	}
 	idxTree := db.hashIndex.trees[string(key)]
 	val, err := db.getVal(idxTree, field, Hash)
-	if err != nil {
+	if err != nil && err != ErrKeyNotFound {
 		return false, err
 	}
 
@@ -72,6 +72,8 @@ func (db *RoseDB) HSetNX(key, field, value []byte) (bool, error) {
 	if val != nil {
 		return false, nil
 	}
+
+	// field doesn't exist in db
 	hashKey := db.encodeKey(key, field)
 	ent := &logfile.LogEntry{Key: hashKey, Value: value}
 	valuePos, err := db.writeLogEntry(ent, Hash)

--- a/hash_test.go
+++ b/hash_test.go
@@ -2,10 +2,11 @@ package rosedb
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
 	"math"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRoseDB_HSet(t *testing.T) {
@@ -124,7 +125,7 @@ func testRoseDBHSetNX(t *testing.T, ioType IOType, mode DataIndexMode) {
 			expErr: nil,
 		},
 		{
-			name:   "Exist key",
+			name:   "Exist key, Non-Exist field",
 			db:     db,
 			key:    []byte("key-1"),
 			field:  []byte("field-3"),
@@ -133,12 +134,21 @@ func testRoseDBHSetNX(t *testing.T, ioType IOType, mode DataIndexMode) {
 			expErr: nil,
 		},
 		{
-			name:   "Non-exist field",
+			name:   "Exist key, Non-Exist field",
 			db:     db,
 			key:    []byte("key-1"),
 			field:  []byte("field-4"),
 			value:  []byte("value-4"),
 			expRes: true,
+			expErr: nil,
+		},
+		{
+			name:   "Exist field",
+			db:     db,
+			key:    []byte("key-1"),
+			field:  []byte("field-1"),
+			value:  []byte("value-3"),
+			expRes: false,
 			expErr: nil,
 		},
 		{


### PR DESCRIPTION
现在主流云厂商的 redis 扩展了不少命令，其中包括 strings cas 指令，rosedb 感觉应该也可以有这个。

`CAS（Compare And Set）`，查看目标key的value是否等于一个指定的值，如果相等，则将value修改为一个新的值；不相等则不修改。

[https://www.alibabacloud.com/help/zh/apsaradb-for-redis/latest/cas-and-cad-commands#concept-2353547](https://www.alibabacloud.com/help/zh/apsaradb-for-redis/latest/cas-and-cad-commands#concept-2353547)