### PR TITLE
Feat/dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 RUN go build -o rosedb-server ./cmd/
 
 
-FROM ubuntu:focal
+FROM alpine:latest
 
 WORKDIR /rosedb
 COPY --from=builder /rosedb/rosedb-server /bin/rosedb-server

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM golang:1.16-alpine as builder
+
+workdir /rosedb
+
+# If you encounter some issues when pulling modules, \
+# you can try to use GOPROXY, especially in China.
+# ENV GOPROXY=https://goproxy.cn
+
+COPY . .
+RUN go build -o rosedb-server ./cmd/
+
+
+FROM ubuntu:focal
+
+WORKDIR /rosedb
+COPY --from=builder /rosedb/rosedb-server /bin/rosedb-server
+
+EXPOSE 5200:5200
+
+ENTRYPOINT ["/bin/rosedb-server", "-host", "0.0.0.0"]
+
+# Usage:
+
+# build rosedb-server image
+# docker build -t rosedb-server .
+
+# print help
+# docker run --rm --name rosedb-server -p 5200:5200 -it rosedb-server -h
+
+# start rosedb-server container
+# docker run --rm --name rosedb-server -p 5200:5200 -d rosedb-server 


### PR DESCRIPTION
## change

add Dockerfile.

## test process

### build

```c
docker build -t rosedb-server .

[+] Building 25.6s (13/13) FINISHED                                                                                                                                                                                                       
 => [internal] load .dockerignore                                                                                                                                                                                                    0.0s
 => => transferring context: 2B                                                                                                                                                                                                      0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                                                 0.0s
 => => transferring dockerfile: 732B                                                                                                                                                                                                 0.0s
 => [internal] load metadata for docker.io/library/golang:1.16-alpine                                                                                                                                                               15.2s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                                                                                                     0.0s
 => [builder 1/4] FROM docker.io/library/golang:1.16-alpine@sha256:41610aabe4ee677934b08685f7ffbeaa89166ed30df9da3f569d1e63789e1992                                                                                                  0.0s
 => [stage-1 1/3] FROM docker.io/library/alpine:latest                                                                                                                                                                               0.0s
 => [internal] load build context                                                                                                                                                                                                    0.0s
 => => transferring context: 17.55kB                                                                                                                                                                                                 0.0s
 => CACHED [builder 2/4] WORKDIR /rosedb                                                                                                                                                                                             0.0s
 => [builder 3/4] COPY . .                                                                                                                                                                                                           0.1s
 => [builder 4/4] RUN go build -o rosedb-server ./cmd/                                                                                                                                                                              10.2s
 => CACHED [stage-1 2/3] WORKDIR /rosedb                                                                                                                                                                                             0.0s
 => [stage-1 3/3] COPY --from=builder /rosedb/rosedb-server /bin/rosedb-server                                                                                                                                                       0.0s
 => exporting to image                                                                                                                                                                                                               0.0s
 => => exporting layers                                                                                                                                                                                                              0.0s
 => => writing image sha256:3d7fbd8bdf23076736b728ab6ccfc7fa494b877d05da73bc5183787ee25e98a6                                                                                                                                         0.0s
 => => naming to docker.io/library/rosedb-server   
```

### image

```c
docker images
REPOSITORY      TAG       IMAGE ID       CREATED             SIZE
rosedb-server   latest    3d7fbd8bdf23   6 minutes ago       9.93MB
```

### test

```c
docker run --rm --name rosedb-server -p 5200:5200 -it rosedb-server -h

Usage of /bin/rosedb-server:
  -databases uint
        the number of databases (default 16)
  -dbpath string
        db path (default "/tmp/rosedb")
  -host string
        server host (default "127.0.0.1")
  -port string
        server port (default "5200")
```

### run

start

```c
docker run --rm --name rosedb-server -p 5200:5200 -d rosedb-server 
adcfedb4166866c12fba2d864b400cc98e65325128cb8a15f8aa6d9f81e06dc5
```

test

```c
redis-cli -p 5200 set key rosedb
OK

 redis-cli -p 5200 get key       
"rosedb"
```
